### PR TITLE
Antennas with a larger number of elements

### DIFF
--- a/src/mmwave/examples/mc-twoenbs.cc
+++ b/src/mmwave/examples/mc-twoenbs.cc
@@ -512,6 +512,10 @@ main (int argc, char *argv[])
   Config::SetDefault ("ns3::MmWave3gppChannel::PortraitMode", BooleanValue (true)); // use blockage model with UT in portrait mode
   Config::SetDefault ("ns3::MmWave3gppChannel::NumNonselfBlocking", IntegerValue (4)); // number of non-self blocking obstacles
 
+  // set the number of antennas in the devices
+  Config::SetDefault ("ns3::McUeNetDevice::AntennaNum", UintegerValue(16));
+  Config::SetDefault ("ns3::MmWaveEnbNetDevice::AntennaNum", UintegerValue(64));
+
   Ptr<MmWaveHelper> mmwaveHelper = CreateObject<MmWaveHelper> ();
   if (true)
     {

--- a/src/mmwave/helper/mmwave-helper.cc
+++ b/src/mmwave/helper/mmwave-helper.cc
@@ -817,7 +817,8 @@ pCtrl->AddCallback (MakeCallback (&LteUePhy::GenerateCtrlCqiReport, phy));
       Ptr<AntennaModel> antenna = (m_ueAntennaModelFactory.Create ())->GetObject<AntennaModel> ();
       DynamicCast<AntennaArrayModel> (antenna)->SetPlanesNumber (m_noUePanels);
       DynamicCast<AntennaArrayModel> (antenna)->SetDeviceType (true);
-      DynamicCast<AntennaArrayModel> (antenna)->SetTotNoArrayElements (m_noRxAntenna);
+      NS_LOG_INFO("MC device->GetAntennaNum() " << device->GetAntennaNum());
+      DynamicCast<AntennaArrayModel> (antenna)->SetTotNoArrayElements (device->GetAntennaNum());
       NS_ASSERT_MSG (antenna, "error in creating the AntennaModel object");
       dlPhy->SetAntenna (antenna);
       ulPhy->SetAntenna (antenna);
@@ -1436,7 +1437,8 @@ pCtrl->AddCallback (MakeCallback (&LteUePhy::GenerateCtrlCqiReport, phy));
       Ptr<AntennaModel> antenna = (m_ueAntennaModelFactory.Create ())->GetObject<AntennaModel> ();
       DynamicCast<AntennaArrayModel> (antenna)->SetPlanesNumber (m_noUePanels);
       DynamicCast<AntennaArrayModel> (antenna)->SetDeviceType (true);
-      DynamicCast<AntennaArrayModel> (antenna)->SetTotNoArrayElements (m_noRxAntenna);
+      NS_LOG_INFO("UE device->GetAntennaNum() " << device->GetAntennaNum());
+      DynamicCast<AntennaArrayModel> (antenna)->SetTotNoArrayElements (device->GetAntennaNum());
       NS_ASSERT_MSG (antenna, "error in creating the AntennaModel object");
       dlPhy->SetAntenna (antenna);
       ulPhy->SetAntenna (antenna);
@@ -1566,6 +1568,7 @@ MmWaveHelper::InstallSingleEnbDevice (Ptr<Node> n)
   //configuration of the phy paramenters
   //2) call SetCcPhyParams
   NS_ASSERT_MSG (m_componentCarrierPhyParams.size () != 0, "Cannot create enb ccm map. Call SetCcPhyParams first.");
+  Ptr<MmWaveEnbNetDevice> device = m_enbNetDeviceFactory.Create<MmWaveEnbNetDevice> ();
 
   // create component carrier map for this eNb device
   std::map<uint8_t,Ptr<MmWaveComponentCarrierEnb> > ccMap;
@@ -1653,7 +1656,8 @@ MmWaveHelper::InstallSingleEnbDevice (Ptr<Node> n)
       Ptr<AntennaModel> antenna = (m_enbAntennaModelFactory.Create ())->GetObject<AntennaModel> ();
       DynamicCast<AntennaArrayModel> (antenna)->SetPlanesNumber (m_noEnbPanels);
       DynamicCast<AntennaArrayModel> (antenna)->SetDeviceType (false);
-      DynamicCast<AntennaArrayModel> (antenna)->SetTotNoArrayElements (m_noTxAntenna);
+      NS_LOG_INFO("eNB device->GetAntennaNum() " << device->GetAntennaNum());
+      DynamicCast<AntennaArrayModel> (antenna)->SetTotNoArrayElements (device->GetAntennaNum());      
       NS_ASSERT_MSG (antenna, "error in creating the AntennaModel object");
       dlPhy->SetAntenna (antenna);
       ulPhy->SetAntenna (antenna);
@@ -1809,8 +1813,6 @@ it->second->GetFfrAlgorithm ()->SetLteFfrRrcSapUser (rrc->GetLteFfrRrcSapUser (i
         }
     }
 
-
-  Ptr<MmWaveEnbNetDevice> device = m_enbNetDeviceFactory.Create<MmWaveEnbNetDevice> ();
   device->SetNode (n);
   device->SetAttribute ("CellId", UintegerValue (cellId));
   device->SetAttribute ("LteEnbComponentCarrierManager", PointerValue (ccmEnbManager));

--- a/src/mmwave/model/antenna-array-model.cc
+++ b/src/mmwave/model/antenna-array-model.cc
@@ -362,7 +362,7 @@ AntennaArrayModel::GetRadiationPattern (double vAngleRadian, double hAngleRadian
 }
 
 Vector
-AntennaArrayModel::GetAntennaLocation (uint8_t index, uint16_t* antennaNum)
+AntennaArrayModel::GetAntennaLocation (uint16_t index, uint16_t* antennaNum)
 {
   //assume the left bottom corner is (0,0,0), and the rectangular antenna array is on the y-z plane.
   Vector loc;

--- a/src/mmwave/model/antenna-array-model.cc
+++ b/src/mmwave/model/antenna-array-model.cc
@@ -206,7 +206,7 @@ AntennaArrayModel::SetBeamformingVectorPanelDevices (Ptr<NetDevice> thisDevice, 
       double hAngleRadian = fmod ((phiAngle + (M_PI / m_noPlane)),2 * M_PI / m_noPlane) - (M_PI / m_noPlane);
       double vAngleRadian = completeAngle.theta;
       double power = 1 / sqrt (m_totNoArrayElements);
-      uint8_t antennaNum [2];
+      uint16_t antennaNum [2];
       antennaNum[0] = sqrt (m_totNoArrayElements);
       antennaNum[1] = sqrt (m_totNoArrayElements);
       NS_LOG_INFO ("hAngleRadian: " << hAngleRadian);
@@ -362,7 +362,7 @@ AntennaArrayModel::GetRadiationPattern (double vAngleRadian, double hAngleRadian
 }
 
 Vector
-AntennaArrayModel::GetAntennaLocation (uint8_t index, uint8_t* antennaNum)
+AntennaArrayModel::GetAntennaLocation (uint8_t index, uint16_t* antennaNum)
 {
   //assume the left bottom corner is (0,0,0), and the rectangular antenna array is on the y-z plane.
   Vector loc;
@@ -373,14 +373,14 @@ AntennaArrayModel::GetAntennaLocation (uint8_t index, uint8_t* antennaNum)
 }
 
 void
-AntennaArrayModel::SetSector (uint8_t sector, uint8_t *antennaNum, double elevation)
+AntennaArrayModel::SetSector (uint8_t sector, uint16_t *antennaNum, double elevation)
 {
   complexVector_t tempVector;
   double hAngle_radian = M_PI * (double)sector / (double)antennaNum[1] - 0.5 * M_PI;
   double vAngle_radian = elevation * M_PI / 180;
-  uint16_t size = antennaNum[0] * antennaNum[1];
+  uint64_t size = antennaNum[0] * antennaNum[1];
   double power = 1 / sqrt (size);
-  for (int ind = 0; ind < size; ind++)
+  for (uint64_t ind = 0; ind < size; ind++)
     {
       Vector loc = GetAntennaLocation (ind, antennaNum);
       double phase = -2 * M_PI * (sin (vAngle_radian) * cos (hAngle_radian) * loc.x

--- a/src/mmwave/model/antenna-array-model.h
+++ b/src/mmwave/model/antenna-array-model.h
@@ -58,7 +58,7 @@ public:
   void ChangeToOmniTx ();
   bool IsOmniTx ();
   double GetRadiationPattern (double vangle, double hangle = 0);
-  Vector GetAntennaLocation (uint8_t index, uint16_t* antennaNum);
+  Vector GetAntennaLocation (uint16_t index, uint16_t* antennaNum);
   void SetSector (uint8_t sector, uint16_t *antennaNum, double elevation = 90);
 
   void SetPlanesNumber (double planesNumber);

--- a/src/mmwave/model/antenna-array-model.h
+++ b/src/mmwave/model/antenna-array-model.h
@@ -58,8 +58,8 @@ public:
   void ChangeToOmniTx ();
   bool IsOmniTx ();
   double GetRadiationPattern (double vangle, double hangle = 0);
-  Vector GetAntennaLocation (uint8_t index, uint8_t* antennaNum);
-  void SetSector (uint8_t sector, uint8_t *antennaNum, double elevation = 90);
+  Vector GetAntennaLocation (uint8_t index, uint16_t* antennaNum);
+  void SetSector (uint8_t sector, uint16_t *antennaNum, double elevation = 90);
 
   void SetPlanesNumber (double planesNumber);
   double GetPlanesId (void);

--- a/src/mmwave/model/mc-ue-net-device.cc
+++ b/src/mmwave/model/mc-ue-net-device.cc
@@ -120,7 +120,7 @@ TypeId McUeNetDevice::GetTypeId (void)
                    UintegerValue (16),
                    MakeUintegerAccessor (&McUeNetDevice::SetAntennaNum,
                                          &McUeNetDevice::GetAntennaNum),
-                   MakeUintegerChecker<uint8_t> ())
+                   MakeUintegerChecker<uint16_t> ())
   ;
   return tid;
 }
@@ -641,14 +641,14 @@ McUeNetDevice::SetMmWaveCcMap (std::map< uint8_t, Ptr<MmWaveComponentCarrierUe> 
 }
 
 
-uint8_t
+uint16_t
 McUeNetDevice::GetAntennaNum () const
 {
   return m_mmWaveAntennaNum;
 }
 
 void
-McUeNetDevice::SetAntennaNum (uint8_t antennaNum)
+McUeNetDevice::SetAntennaNum (uint16_t antennaNum)
 {
   m_mmWaveAntennaNum = antennaNum;
 }

--- a/src/mmwave/model/mc-ue-net-device.cc
+++ b/src/mmwave/model/mc-ue-net-device.cc
@@ -650,6 +650,7 @@ McUeNetDevice::GetAntennaNum () const
 void
 McUeNetDevice::SetAntennaNum (uint16_t antennaNum)
 {
+  NS_ASSERT_MSG (std::floor (std::sqrt(antennaNum)) == std::sqrt(antennaNum), "Only square antenna arrays are currently supported.");
   m_mmWaveAntennaNum = antennaNum;
 }
 

--- a/src/mmwave/model/mc-ue-net-device.h
+++ b/src/mmwave/model/mc-ue-net-device.h
@@ -214,9 +214,9 @@ public:
 
   Ptr<MmWaveEnbNetDevice> GetMmWaveTargetEnb (void);
 
-  void SetAntennaNum (uint8_t antennaNum);
+  void SetAntennaNum (uint16_t antennaNum);
 
-  uint8_t GetAntennaNum () const;
+  uint16_t GetAntennaNum () const;
 
 protected:
   NetDevice::ReceiveCallback m_rxCallback;
@@ -262,7 +262,7 @@ private:
   Ptr<LteUeComponentCarrierManager> m_mmWaveComponentCarrierManager; ///< mmWave component carrier manager
   std::map < uint8_t, Ptr<MmWaveComponentCarrierUe> > m_mmWaveCcMap; ///< mmWave CC map
   uint16_t m_mmWaveEarfcn; /**< MmWave carrier frequency */
-  uint8_t m_mmWaveAntennaNum;
+  uint16_t m_mmWaveAntennaNum;
 
   // Common
   Ptr<EpcUeNas> m_nas;

--- a/src/mmwave/model/mmwave-3gpp-channel.cc
+++ b/src/mmwave/model/mmwave-3gpp-channel.cc
@@ -417,8 +417,8 @@ MmWave3gppChannel::DoCalcRxPowerSpectralDensity (Ptr<const SpectrumValue> txPsd,
 
   /* txAntennaNum[0]-number of vertical antenna elements
    * txAntennaNum[1]-number of horizontal antenna elements*/
-  uint8_t txAntennaNum[2];
-  uint8_t rxAntennaNum[2];
+  uint16_t txAntennaNum[2];
+  uint16_t rxAntennaNum[2];
   Ptr<AntennaArrayModel> txAntennaArray, rxAntennaArray;
 
   Vector locUT;
@@ -1485,7 +1485,7 @@ MmWave3gppChannel::DeleteChannel (Ptr<const MobilityModel> a, Ptr<const Mobility
 Ptr<Params3gpp>
 MmWave3gppChannel::GetNewChannel (Ptr<ParamsTable>  table3gpp, Vector locUT, bool los, bool o2i,
                                   Ptr<AntennaArrayModel> txAntenna, Ptr<AntennaArrayModel> rxAntenna,
-                                  uint8_t *txAntennaNum, uint8_t *rxAntennaNum,  Angles &rxAngle, Angles &txAngle,
+                                  uint16_t *txAntennaNum, uint16_t *rxAntennaNum,  Angles &rxAngle, Angles &txAngle,
                                   Vector speed, double dis2D, double dis3D) const
 {
   uint8_t numOfCluster = table3gpp->m_numOfCluster;
@@ -2052,8 +2052,8 @@ MmWave3gppChannel::GetNewChannel (Ptr<ParamsTable>  table3gpp, Vector locUT, boo
 
   complex3DVector_t H_NLOS;       // channel coefficients H_NLOS [u][s][n],
   // where u and s are receive and transmit antenna element, n is cluster index.
-  uint16_t uSize = rxAntennaNum[0] * rxAntennaNum[1];
-  uint16_t sSize = txAntennaNum[0] * txAntennaNum[1];
+  uint64_t uSize = rxAntennaNum[0] * rxAntennaNum[1];
+  uint64_t sSize = txAntennaNum[0] * txAntennaNum[1];
 
   uint8_t cluster1st = 0, cluster2nd = 0;       // first and second strongest cluster;
   double maxPower = 0;
@@ -2081,21 +2081,21 @@ MmWave3gppChannel::GetNewChannel (Ptr<ParamsTable>  table3gpp, Vector locUT, boo
   //Since each of the strongest 2 clusters are divided into 3 sub-clusters, the total cluster will be numReducedCLuster + 4.
 
   H_usn.resize (uSize);
-  for (uint16_t uIndex = 0; uIndex < uSize; uIndex++)
+  for (uint64_t uIndex = 0; uIndex < uSize; uIndex++)
     {
       H_usn.at (uIndex).resize (sSize);
-      for (uint16_t sIndex = 0; sIndex < sSize; sIndex++)
+      for (uint64_t sIndex = 0; sIndex < sSize; sIndex++)
         {
           H_usn.at (uIndex).at (sIndex).resize (numReducedCluster);
         }
     }
   //double slotTime = Simulator::Now ().GetSeconds ();
   // The following for loops computes the channel coefficients
-  for (uint16_t uIndex = 0; uIndex < uSize; uIndex++)
+  for (uint64_t uIndex = 0; uIndex < uSize; uIndex++)
     {
       Vector uLoc = rxAntenna->GetAntennaLocation (uIndex,rxAntennaNum);
 
-      for (uint16_t sIndex = 0; sIndex < sSize; sIndex++)
+      for (uint64_t sIndex = 0; sIndex < sSize; sIndex++)
         {
 
           Vector sLoc = txAntenna->GetAntennaLocation (sIndex,txAntennaNum);
@@ -2326,7 +2326,7 @@ MmWave3gppChannel::GetNewChannel (Ptr<ParamsTable>  table3gpp, Vector locUT, boo
 Ptr<Params3gpp>
 MmWave3gppChannel::UpdateChannel (Ptr<Params3gpp> params3gpp, Ptr<ParamsTable>  table3gpp,
                                   Ptr<AntennaArrayModel> txAntenna, Ptr<AntennaArrayModel> rxAntenna,
-                                  uint8_t *txAntennaNum, uint8_t *rxAntennaNum, Angles &rxAngle, Angles &txAngle) const
+                                  uint16_t *txAntennaNum, uint16_t *rxAntennaNum, Angles &rxAngle, Angles &txAngle) const
 {
   Ptr<Params3gpp> params = params3gpp;
   uint8_t raysPerCluster = table3gpp->m_raysPerCluster;
@@ -2709,8 +2709,8 @@ MmWave3gppChannel::UpdateChannel (Ptr<Params3gpp> params3gpp, Ptr<ParamsTable>  
 
   complex3DVector_t H_NLOS;       // channel coefficients H_NLOS [u][s][n],
   // where u and s are receive and transmit antenna element, n is cluster index.
-  uint16_t uSize = rxAntennaNum[0] * rxAntennaNum[1];
-  uint16_t sSize = txAntennaNum[0] * txAntennaNum[1];
+  uint64_t uSize = rxAntennaNum[0] * rxAntennaNum[1];
+  uint64_t sSize = txAntennaNum[0] * txAntennaNum[1];
 
   uint8_t cluster1st = 0, cluster2nd = 0;       // first and second strongest cluster;
   double maxPower = 0;
@@ -2738,21 +2738,21 @@ MmWave3gppChannel::UpdateChannel (Ptr<Params3gpp> params3gpp, Ptr<ParamsTable>  
   //Since each of the strongest 2 clusters are divided into 3 sub-clusters, the total cluster will be numReducedCLuster + 4.
 
   H_usn.resize (uSize);
-  for (uint16_t uIndex = 0; uIndex < uSize; uIndex++)
+  for (uint64_t uIndex = 0; uIndex < uSize; uIndex++)
     {
       H_usn.at (uIndex).resize (sSize);
-      for (uint16_t sIndex = 0; sIndex < sSize; sIndex++)
+      for (uint64_t sIndex = 0; sIndex < sSize; sIndex++)
         {
           H_usn.at (uIndex).at (sIndex).resize (params->m_numCluster);
         }
     }
   //double slotTime = Simulator::Now ().GetSeconds ();
   // The following for loops computes the channel coefficients
-  for (uint16_t uIndex = 0; uIndex < uSize; uIndex++)
+  for (uint64_t uIndex = 0; uIndex < uSize; uIndex++)
     {
       Vector uLoc = rxAntenna->GetAntennaLocation (uIndex,rxAntennaNum);
 
-      for (uint16_t sIndex = 0; sIndex < sSize; sIndex++)
+      for (uint64_t sIndex = 0; sIndex < sSize; sIndex++)
         {
 
           Vector sLoc = txAntenna->GetAntennaLocation (sIndex,txAntennaNum);
@@ -2962,7 +2962,7 @@ MmWave3gppChannel::UpdateChannel (Ptr<Params3gpp> params3gpp, Ptr<ParamsTable>  
 
 void
 MmWave3gppChannel::BeamSearchBeamforming (Ptr<const SpectrumValue> txPsd, Ptr<Params3gpp> params, Ptr<AntennaArrayModel> txAntenna,
-                                          Ptr<AntennaArrayModel> rxAntenna, uint8_t *txAntennaNum, uint8_t *rxAntennaNum) const
+                                          Ptr<AntennaArrayModel> rxAntenna, uint16_t *txAntennaNum, uint16_t *rxAntennaNum) const
 {
   double max = 0, maxTx = 0, maxRx = 0, maxTxTheta = 0, maxRxTheta = 0;
   NS_LOG_LOGIC ("BeamSearchBeamforming method at time " << Simulator::Now ().GetSeconds ());

--- a/src/mmwave/model/mmwave-3gpp-channel.cc
+++ b/src/mmwave/model/mmwave-3gpp-channel.cc
@@ -1021,25 +1021,25 @@ void
 MmWave3gppChannel::LongTermCovMatrixBeamforming (Ptr<Params3gpp> params) const
 {
   //generate transmitter side spatial correlation matrix
-  uint8_t txSize = params->m_channel.at (0).size ();
-  uint8_t rxSize = params->m_channel.size ();
+  uint16_t txSize = params->m_channel.at (0).size ();
+  uint16_t rxSize = params->m_channel.size ();
   complex2DVector_t txQ;
   txQ.resize (txSize);
 
-  for (uint8_t txIndex = 0; txIndex < txSize; txIndex++)
+  for (uint16_t txIndex = 0; txIndex < txSize; txIndex++)
     {
       txQ.at (txIndex).resize (txSize);
     }
 
   //compute the transmitter side spatial correlation matrix txQ = H*H, where H is the sum of H_n over n clusters.
-  for (uint8_t t1Index = 0; t1Index < txSize; t1Index++)
+  for (uint16_t t1Index = 0; t1Index < txSize; t1Index++)
     {
-      for (uint8_t t2Index = 0; t2Index < txSize; t2Index++)
+      for (uint16_t t2Index = 0; t2Index < txSize; t2Index++)
         {
-          for (uint8_t rxIndex = 0; rxIndex < rxSize; rxIndex++)
+          for (uint16_t rxIndex = 0; rxIndex < rxSize; rxIndex++)
             {
               std::complex<double> cSum (0,0);
-              for (uint8_t cIndex = 0; cIndex < params->m_channel.at (rxIndex).at (t1Index).size (); cIndex++)
+              for (uint16_t cIndex = 0; cIndex < params->m_channel.at (rxIndex).at (t1Index).size (); cIndex++)
                 {
                   cSum = cSum + std::conj (params->m_channel.at (rxIndex).at (t1Index).at (cIndex)) *
                     (params->m_channel.at (rxIndex).at (t2Index).at (cIndex));
@@ -1053,8 +1053,8 @@ MmWave3gppChannel::LongTermCovMatrixBeamforming (Ptr<Params3gpp> params) const
 
   //calculate beamforming vector from spatial correlation matrix.
   complexVector_t antennaWeights;
-  uint8_t txAntenna = txQ.size ();
-  for (uint8_t eIndex = 0; eIndex < txAntenna; eIndex++)
+  uint16_t txAntenna = txQ.size ();
+  for (uint16_t eIndex = 0; eIndex < txAntenna; eIndex++)
     {
       antennaWeights.push_back (txQ.at (0).at (eIndex));
     }
@@ -1066,10 +1066,10 @@ MmWave3gppChannel::LongTermCovMatrixBeamforming (Ptr<Params3gpp> params) const
     {
       complexVector_t antennaWeights_New;
 
-      for (uint8_t row = 0; row < txAntenna; row++)
+      for (uint16_t row = 0; row < txAntenna; row++)
         {
           std::complex<double> sum (0,0);
-          for (uint8_t col = 0; col < txAntenna; col++)
+          for (uint16_t col = 0; col < txAntenna; col++)
             {
               sum += txQ.at (row).at (col) * antennaWeights.at (col);
             }
@@ -1078,16 +1078,16 @@ MmWave3gppChannel::LongTermCovMatrixBeamforming (Ptr<Params3gpp> params) const
         }
       //normalize antennaWeights;
       double weightSum = 0;
-      for (uint8_t i = 0; i < txAntenna; i++)
+      for (uint16_t i = 0; i < txAntenna; i++)
         {
           weightSum += norm (antennaWeights_New.at (i));
         }
-      for (uint8_t i = 0; i < txAntenna; i++)
+      for (uint16_t i = 0; i < txAntenna; i++)
         {
           antennaWeights_New.at (i) = antennaWeights_New.at (i) / sqrt (weightSum);
         }
       diff = 0;
-      for (uint8_t i = 0; i < txAntenna; i++)
+      for (uint16_t i = 0; i < txAntenna; i++)
         {
           diff += std::norm (antennaWeights_New.at (i) - antennaWeights.at (i));
         }
@@ -1100,19 +1100,19 @@ MmWave3gppChannel::LongTermCovMatrixBeamforming (Ptr<Params3gpp> params) const
   //compute the receiver side spatial correlation matrix rxQ = HH*, where H is the sum of H_n over n clusters.
   complex2DVector_t rxQ;
   rxQ.resize (rxSize);
-  for (uint8_t r1Index = 0; r1Index < rxSize; r1Index++)
+  for (uint16_t r1Index = 0; r1Index < rxSize; r1Index++)
     {
       rxQ.at (r1Index).resize (rxSize);
     }
 
-  for (uint8_t r1Index = 0; r1Index < rxSize; r1Index++)
+  for (uint16_t r1Index = 0; r1Index < rxSize; r1Index++)
     {
-      for (uint8_t r2Index = 0; r2Index < rxSize; r2Index++)
+      for (uint16_t r2Index = 0; r2Index < rxSize; r2Index++)
         {
-          for (uint8_t txIndex = 0; txIndex < txSize; txIndex++)
+          for (uint16_t txIndex = 0; txIndex < txSize; txIndex++)
             {
               std::complex<double> cSum (0,0);
-              for (uint8_t cIndex = 0; cIndex < params->m_channel.at (r1Index).at (txIndex).size (); cIndex++)
+              for (uint16_t cIndex = 0; cIndex < params->m_channel.at (r1Index).at (txIndex).size (); cIndex++)
                 {
                   cSum = cSum + params->m_channel.at (r1Index).at (txIndex).at (cIndex) *
                     std::conj (params->m_channel.at (r2Index).at (txIndex).at (cIndex));
@@ -1125,8 +1125,8 @@ MmWave3gppChannel::LongTermCovMatrixBeamforming (Ptr<Params3gpp> params) const
 
   //calculate beamforming vector from spatial correlation matrix.
   antennaWeights.clear ();
-  uint8_t rxAntenna = rxQ.size ();
-  for (uint8_t eIndex = 0; eIndex < rxAntenna; eIndex++)
+  uint16_t rxAntenna = rxQ.size ();
+  for (uint16_t eIndex = 0; eIndex < rxAntenna; eIndex++)
     {
       antennaWeights.push_back (rxQ.at (0).at (eIndex));
     }
@@ -1137,10 +1137,10 @@ MmWave3gppChannel::LongTermCovMatrixBeamforming (Ptr<Params3gpp> params) const
     {
       complexVector_t antennaWeights_New;
 
-      for (uint8_t row = 0; row < rxAntenna; row++)
+      for (uint16_t row = 0; row < rxAntenna; row++)
         {
           std::complex<double> sum (0,0);
-          for (uint8_t col = 0; col < rxAntenna; col++)
+          for (uint16_t col = 0; col < rxAntenna; col++)
             {
               sum += rxQ.at (row).at (col) * antennaWeights.at (col);
             }
@@ -1150,16 +1150,16 @@ MmWave3gppChannel::LongTermCovMatrixBeamforming (Ptr<Params3gpp> params) const
 
       //normalize antennaWeights;
       double weightSum = 0;
-      for (uint8_t i = 0; i < rxAntenna; i++)
+      for (uint16_t i = 0; i < rxAntenna; i++)
         {
           weightSum += norm (antennaWeights_New.at (i));
         }
-      for (uint8_t i = 0; i < rxAntenna; i++)
+      for (uint16_t i = 0; i < rxAntenna; i++)
         {
           antennaWeights_New.at (i) = antennaWeights_New.at (i) / sqrt (weightSum);
         }
       diff = 0;
-      for (uint8_t i = 0; i < rxAntenna; i++)
+      for (uint16_t i = 0; i < rxAntenna; i++)
         {
           diff += std::norm (antennaWeights_New.at (i) - antennaWeights.at (i));
         }
@@ -1253,8 +1253,8 @@ MmWave3gppChannel::SetPathlossModel (Ptr<PropagationLossModel> pathloss)
 complexVector_t
 MmWave3gppChannel::CalLongTerm (Ptr<Params3gpp> params) const
 {
-  uint8_t txAntenna = params->m_txW.size ();
-  uint8_t rxAntenna = params->m_rxW.size ();
+  uint16_t txAntenna = params->m_txW.size ();
+  uint16_t rxAntenna = params->m_rxW.size ();
 
   NS_LOG_DEBUG ("CalLongTerm with txAntenna " << (uint16_t)txAntenna << " rxAntenna " << (uint16_t)rxAntenna);
   //store the long term part to reduce computation load
@@ -1265,10 +1265,10 @@ MmWave3gppChannel::CalLongTerm (Ptr<Params3gpp> params) const
   for (uint8_t cIndex = 0; cIndex < numCluster; cIndex++)
     {
       std::complex<double> txSum (0,0);
-      for (uint8_t txIndex = 0; txIndex < txAntenna; txIndex++)
+      for (uint16_t txIndex = 0; txIndex < txAntenna; txIndex++)
         {
           std::complex<double> rxSum (0,0);
-          for (uint8_t rxIndex = 0; rxIndex < rxAntenna; rxIndex++)
+          for (uint16_t rxIndex = 0; rxIndex < rxAntenna; rxIndex++)
             {
               rxSum = rxSum + std::conj (params->m_rxW.at (rxIndex)) * params->m_channel.at (rxIndex).at (txIndex).at (cIndex);
             }

--- a/src/mmwave/model/mmwave-3gpp-channel.h
+++ b/src/mmwave/model/mmwave-3gpp-channel.h
@@ -264,7 +264,7 @@ private:
    */
   Ptr<Params3gpp> GetNewChannel (Ptr<ParamsTable> table3gpp, Vector locUT, bool los, bool o2i,
                                  Ptr<AntennaArrayModel> txAntenna, Ptr<AntennaArrayModel> rxAntenna,
-                                 uint8_t *txAntennaNum, uint8_t *rxAntennaNum, Angles &rxAngle, Angles &txAngle,
+                                 uint16_t *txAntennaNum, uint16_t *rxAntennaNum, Angles &rxAngle, Angles &txAngle,
                                  Vector speed, double dis2D, double dis3D) const;
 
   /**
@@ -282,7 +282,7 @@ private:
    */
   Ptr<Params3gpp> UpdateChannel (Ptr<Params3gpp> params3gpp, Ptr<ParamsTable> table3gpp,
                                  Ptr<AntennaArrayModel> txAntenna, Ptr<AntennaArrayModel> rxAntenna,
-                                 uint8_t *txAntennaNum, uint8_t *rxAntennaNum, Angles &rxAngle, Angles &txAngle) const;
+                                 uint16_t *txAntennaNum, uint16_t *rxAntennaNum, Angles &rxAngle, Angles &txAngle) const;
 
   /**
    * Compute the optimal BF vector with the Power Method (Maximum Ratio Transmission method).
@@ -297,7 +297,7 @@ private:
    * @params the channel realizationin as a Params3gpp object
    */
   void BeamSearchBeamforming (Ptr<const SpectrumValue> txPsd, Ptr<Params3gpp> params, Ptr<AntennaArrayModel> txAntenna,
-                              Ptr<AntennaArrayModel> rxAntenna, uint8_t *txAntennaNum, uint8_t *rxAntennaNum) const;
+                              Ptr<AntennaArrayModel> rxAntenna, uint16_t *txAntennaNum, uint16_t *rxAntennaNum) const;
 
 
   /**

--- a/src/mmwave/model/mmwave-channel-matrix.cc
+++ b/src/mmwave/model/mmwave-channel-matrix.cc
@@ -160,8 +160,8 @@ MmWaveChannelMatrix::DoCalcRxPowerSpectralDensity (Ptr<const SpectrumValue> txPs
   Ptr<mmwave::MmWaveUeNetDevice> rxUe =
     DynamicCast<mmwave::MmWaveUeNetDevice> (rxDevice);
 
-  uint8_t txAntennaNum[2];
-  uint8_t rxAntennaNum[2];
+  uint16_t txAntennaNum[2];
+  uint16_t rxAntennaNum[2];
 
   if (txEnb != 0 && rxUe != 0)
     {
@@ -490,7 +490,7 @@ MmWaveChannelMatrix::CalcBeamformingVector(complex2DVector_t spatialMatrix) cons
 
 
 complex2DVector_t
-MmWaveChannelMatrix::GenSpatialMatrix (std::vector<uint16_t> cluster, Angles angle, uint8_t* antennaNum) const
+MmWaveChannelMatrix::GenSpatialMatrix (std::vector<uint16_t> cluster, Angles angle, uint16_t* antennaNum) const
 {
   complex2DVector_t spatialMatrix;
   for (unsigned int clusterIndex = 0; clusterIndex < cluster.size (); clusterIndex++)
@@ -522,16 +522,16 @@ MmWaveChannelMatrix::GenSpatialMatrix (std::vector<uint16_t> cluster, Angles ang
 
 
 complexVector_t
-MmWaveChannelMatrix::GenSinglePath (double hAngle, double vAngle, uint8_t* antennaNum) const
+MmWaveChannelMatrix::GenSinglePath (double hAngle, double vAngle, uint16_t* antennaNum) const
 {
   NS_LOG_FUNCTION (this);
   complexVector_t singlePath;
-  uint16_t vSize = antennaNum[0];
-  uint16_t hSize = antennaNum[1];
+  uint64_t vSize = antennaNum[0];
+  uint64_t hSize = antennaNum[1];
 
-  for (int vIndex = 0; vIndex < vSize; vIndex++)
+  for (uint64_t vIndex = 0; vIndex < vSize; vIndex++)
     {
-      for (int hIndex = 0; hIndex < hSize; hIndex++)
+      for (uint64_t hIndex = 0; hIndex < hSize; hIndex++)
         {
           double w = (-2) * M_PI * hIndex * m_antennaSeparation * cos (hAngle)
             + (-2) * M_PI * vIndex * m_antennaSeparation * cos (vAngle);

--- a/src/mmwave/model/mmwave-channel-matrix.h
+++ b/src/mmwave/model/mmwave-channel-matrix.h
@@ -101,8 +101,8 @@ private:
                                                    Ptr<const MobilityModel> a,
                                                    Ptr<const MobilityModel> b) const;
 
-  complex2DVector_t GenSpatialMatrix (std::vector<uint16_t> cluster, Angles angle, uint8_t* antennaNum) const;
-  complexVector_t GenSinglePath (double hAngle, double vAngle, uint8_t* antennaNum) const;
+  complex2DVector_t GenSpatialMatrix (std::vector<uint16_t> cluster, Angles angle, uint16_t* antennaNum) const;
+  complexVector_t GenSinglePath (double hAngle, double vAngle, uint16_t* antennaNum) const;
   //complexVector_t CalcBeamformingVector (complex2DVector_t SpatialMatrix) const;
   Ptr<SpectrumValue> GetChannelGain (Ptr<const SpectrumValue> txPsd, Ptr<mmWaveBeamFormingParams> bfParams, double speed) const;
   double GetSystemBandwidth () const;

--- a/src/mmwave/model/mmwave-channel-raytracing.cc
+++ b/src/mmwave/model/mmwave-channel-raytracing.cc
@@ -264,8 +264,8 @@ MmWaveChannelRaytracing::DoCalcRxPowerSpectralDensity (Ptr<const SpectrumValue> 
   Ptr<mmwave::MmWaveUeNetDevice> rxUe =
     DynamicCast<mmwave::MmWaveUeNetDevice> (rxDevice);
 
-  uint8_t txAntennaNum[2];
-  uint8_t rxAntennaNum[2];
+  uint16_t txAntennaNum[2];
+  uint16_t rxAntennaNum[2];
 
   bool dl = true;
 
@@ -570,7 +570,7 @@ MmWaveChannelRaytracing::CalcBeamformingVector (complex2DVector_t spatialMatrix,
 
 
 complex2DVector_t
-MmWaveChannelRaytracing::GenSpatialMatrix (uint64_t traceIndex, uint8_t* antennaNum, bool bs) const
+MmWaveChannelRaytracing::GenSpatialMatrix (uint64_t traceIndex, uint16_t* antennaNum, bool bs) const
 {
   complex2DVector_t spatialMatrix;
   uint16_t pathNum = g_path.at (traceIndex);
@@ -598,16 +598,16 @@ MmWaveChannelRaytracing::GenSpatialMatrix (uint64_t traceIndex, uint8_t* antenna
 
 
 complexVector_t
-MmWaveChannelRaytracing::GenSinglePath (double hAngle, double vAngle, uint8_t* antennaNum) const
+MmWaveChannelRaytracing::GenSinglePath (double hAngle, double vAngle, uint16_t* antennaNum) const
 {
   NS_LOG_FUNCTION (this);
   complexVector_t singlePath;
-  uint16_t vSize = antennaNum[0];
-  uint16_t hSize = antennaNum[1];
+  uint64_t vSize = antennaNum[0];
+  uint64_t hSize = antennaNum[1];
 
-  for (int vIndex = 0; vIndex < vSize; vIndex++)
+  for (uint64_t vIndex = 0; vIndex < vSize; vIndex++)
     {
-      for (int hIndex = 0; hIndex < hSize; hIndex++)
+      for (uint64_t hIndex = 0; hIndex < hSize; hIndex++)
         {
           double w = (-2) * M_PI * hIndex * m_antennaSeparation * cos (hAngle)
             + (-2) * M_PI * vIndex * m_antennaSeparation * cos (vAngle);

--- a/src/mmwave/model/mmwave-channel-raytracing.h
+++ b/src/mmwave/model/mmwave-channel-raytracing.h
@@ -102,8 +102,8 @@ private:
                                                    Ptr<const MobilityModel> a,
                                                    Ptr<const MobilityModel> b) const;
 
-  complex2DVector_t GenSpatialMatrix (uint64_t traceIndex, uint8_t* antennaNum, bool bs) const;
-  complexVector_t GenSinglePath (double hAngle, double vAngle, uint8_t* antennaNum) const;
+  complex2DVector_t GenSpatialMatrix (uint64_t traceIndex, uint16_t* antennaNum, bool bs) const;
+  complexVector_t GenSinglePath (double hAngle, double vAngle, uint16_t* antennaNum) const;
   complexVector_t CalcBeamformingVector (complex2DVector_t SpatialMatrix, doubleVector_t powerFraction) const;
   Ptr<SpectrumValue> GetChannelGain (Ptr<const SpectrumValue> txPsd, Ptr<mmWaveBeamFormingTraces> bfParams, double speed) const;
   double GetSystemBandwidth () const;

--- a/src/mmwave/model/mmwave-enb-net-device.cc
+++ b/src/mmwave/model/mmwave-enb-net-device.cc
@@ -238,6 +238,7 @@ MmWaveEnbNetDevice::GetRrc (void)
 void
 MmWaveEnbNetDevice::SetAntennaNum (uint16_t antennaNum)
 {
+  NS_ASSERT_MSG (std::floor (std::sqrt(antennaNum)) == std::sqrt(antennaNum), "Only square antenna arrays are currently supported.");
   m_antennaNum = antennaNum;
 }
 uint16_t

--- a/src/mmwave/model/mmwave-enb-net-device.cc
+++ b/src/mmwave/model/mmwave-enb-net-device.cc
@@ -90,7 +90,7 @@ TypeId MmWaveEnbNetDevice::GetTypeId ()
                    UintegerValue (64),
                    MakeUintegerAccessor (&MmWaveEnbNetDevice::SetAntennaNum,
                                          &MmWaveEnbNetDevice::GetAntennaNum),
-                   MakeUintegerChecker<uint8_t> ())
+                   MakeUintegerChecker<uint16_t> ())
   ;
 
   return tid;
@@ -236,11 +236,11 @@ MmWaveEnbNetDevice::GetRrc (void)
 }
 
 void
-MmWaveEnbNetDevice::SetAntennaNum (uint8_t antennaNum)
+MmWaveEnbNetDevice::SetAntennaNum (uint16_t antennaNum)
 {
   m_antennaNum = antennaNum;
 }
-uint8_t
+uint16_t
 MmWaveEnbNetDevice::GetAntennaNum () const
 {
   return m_antennaNum;

--- a/src/mmwave/model/mmwave-enb-net-device.h
+++ b/src/mmwave/model/mmwave-enb-net-device.h
@@ -97,9 +97,9 @@ public:
 
   Ptr<LteEnbRrc> GetRrc (void);
 
-  void SetAntennaNum (uint8_t antennaNum);
+  void SetAntennaNum (uint16_t antennaNum);
 
-  uint8_t GetAntennaNum () const;
+  uint16_t GetAntennaNum () const;
 
   std::map < uint8_t, Ptr<MmWaveComponentCarrierEnb> > GetCcMap ();
 
@@ -121,7 +121,7 @@ private:
 
   uint16_t m_Earfcn;        /* carrier frequency */
 
-  uint8_t m_antennaNum;
+  uint16_t m_antennaNum;
 
   std::map < uint8_t, Ptr<MmWaveComponentCarrierEnb> > m_ccMap;       /**< ComponentCarrier map */
 

--- a/src/mmwave/model/mmwave-ue-net-device.cc
+++ b/src/mmwave/model/mmwave-ue-net-device.cc
@@ -308,6 +308,7 @@ void
 MmWaveUeNetDevice::SetAntennaNum (uint16_t antennaNum)
 {
   NS_LOG_FUNCTION (this << antennaNum);
+  NS_ASSERT_MSG (std::floor (std::sqrt(antennaNum)) == std::sqrt(antennaNum), "Only square antenna arrays are currently supported.");
   m_antennaNum = antennaNum;
 }
 

--- a/src/mmwave/model/mmwave-ue-net-device.cc
+++ b/src/mmwave/model/mmwave-ue-net-device.cc
@@ -99,7 +99,7 @@ MmWaveUeNetDevice::GetTypeId (void)
                    UintegerValue (16),
                    MakeUintegerAccessor (&MmWaveUeNetDevice::SetAntennaNum,
                                          &MmWaveUeNetDevice::GetAntennaNum),
-                   MakeUintegerChecker<uint8_t> ())
+                   MakeUintegerChecker<uint16_t> ())
     .AddAttribute ("LteUeRrc",
                    "The RRC layer associated with the ENB",
                    PointerValue (),
@@ -297,7 +297,7 @@ MmWaveUeNetDevice::SetCcMap (std::map< uint8_t, Ptr<MmWaveComponentCarrierUe> > 
 }
 
 
-uint8_t
+uint16_t
 MmWaveUeNetDevice::GetAntennaNum () const
 {
   NS_LOG_FUNCTION (this);
@@ -305,7 +305,7 @@ MmWaveUeNetDevice::GetAntennaNum () const
 }
 
 void
-MmWaveUeNetDevice::SetAntennaNum (uint8_t antennaNum)
+MmWaveUeNetDevice::SetAntennaNum (uint16_t antennaNum)
 {
   NS_LOG_FUNCTION (this << antennaNum);
   m_antennaNum = antennaNum;

--- a/src/mmwave/model/mmwave-ue-net-device.h
+++ b/src/mmwave/model/mmwave-ue-net-device.h
@@ -98,9 +98,9 @@ public:
 
   Ptr<MmWaveEnbNetDevice> GetTargetEnb (void);
 
-  void SetAntennaNum (uint8_t antennaNum);
+  void SetAntennaNum (uint16_t antennaNum);
 
-  uint8_t GetAntennaNum () const;
+  uint16_t GetAntennaNum () const;
 
   std::map < uint8_t, Ptr<MmWaveComponentCarrierUe> > GetCcMap ();
 
@@ -130,7 +130,7 @@ private:
 
   std::map < uint8_t, Ptr<MmWaveComponentCarrierUe> > m_ccMap;       ///< CC map
 
-  uint8_t m_antennaNum;
+  uint16_t m_antennaNum;
 
 
 };


### PR DESCRIPTION
The type of the "AntennaNum" attribute has been changed to uint16_t in all the mmwave devices classes. Now BSs and UEs can use square antennas with a larger number of elements.