### PR TITLE
Fix MmWaveFlexTtiMacScheduler::CalcMinTbSizeNumSym

### DIFF
--- a/src/mmwave/model/mmwave-flex-tti-maxrate-mac-scheduler.cc
+++ b/src/mmwave/model/mmwave-flex-tti-maxrate-mac-scheduler.cc
@@ -708,44 +708,51 @@ MmWaveFlexTtiMaxRateMacScheduler::UpdateUlHarqProcessId (uint16_t rnti)
 
 unsigned MmWaveFlexTtiMaxRateMacScheduler::CalcMinTbSizeNumSym (unsigned mcs, unsigned bufSize, unsigned &tbSize)
 {
-  // bisection line search to find minimum number of slots needed to encode entire buffer
+  // Bisection line search is used to find the minimum number of slots (OFDM symbols)
+  // needed to encode entire buffer.
   MmWaveMacPduHeader dummyMacHeader;
   //unsigned macHdrSize = 10; //dummyMacHeader.GetSerializedSize ();
   int numSymLow = 0;
-  int numSymHigh = m_phyMacConfig->GetSymbolsPerSubframe ();
+  int numSymHigh = m_phyMacConfig->GetSymbolsPerSubframe();
 
   int diff = 0;
-  tbSize = (m_amc->GetTbSizeFromMcsSymbols (mcs, numSymHigh) / 8);       // start with max value
+  tbSize = (m_amc->GetTbSizeFromMcsSymbols (mcs, numSymHigh) / 8); // start with max value, in number of bytes
   while ((unsigned)tbSize > bufSize)
-    {
-      diff = abs (numSymHigh - numSymLow) / 2;
+  {
+      diff = abs(numSymHigh-numSymLow)/2;
       if (diff == 0)
-        {
+      {
           tbSize = (m_amc->GetTbSizeFromMcsSymbols (mcs, numSymHigh) / 8);
           return numSymHigh;
-        }
+      }
       tbSize = (m_amc->GetTbSizeFromMcsSymbols (mcs, numSymHigh - diff) / 8);
-      if ((unsigned)tbSize > bufSize)
-        {
+      if ((unsigned)tbSize >= bufSize)
+      {
           numSymHigh -= diff;
-        }
+      }
+      if ((unsigned) tbSize == bufSize)
+      {
+          return numSymHigh;
+      }
       while ((unsigned)tbSize < bufSize)
-        {
-          diff = abs (numSymHigh - numSymLow) / 2;
+      {
+          diff = abs(numSymHigh-numSymLow)/2;
           if (diff == 0)
-            {
+          {
               tbSize = (m_amc->GetTbSizeFromMcsSymbols (mcs, numSymHigh) / 8);
               return numSymHigh;
-            }
-          //tmp2 = numSym;
+          }
           tbSize = (m_amc->GetTbSizeFromMcsSymbols (mcs, numSymLow + diff) / 8);
-          if ((unsigned)tbSize < bufSize)
-            {
+          if ((unsigned)tbSize <= bufSize)
+          {
               numSymLow += diff;
-            }
-        }
-    }
-
+          }
+          if ((unsigned) tbSize == bufSize)
+          {
+              return numSymLow;
+          }
+      }
+  }
   tbSize = (m_amc->GetTbSizeFromMcsSymbols (mcs, numSymHigh) / 8);
   return (unsigned)numSymHigh;
 }

--- a/src/mmwave/model/mmwave-flex-tti-maxweight-mac-scheduler.cc
+++ b/src/mmwave/model/mmwave-flex-tti-maxweight-mac-scheduler.cc
@@ -707,44 +707,51 @@ MmWaveFlexTtiMaxWeightMacScheduler::UpdateUlHarqProcessId (uint16_t rnti)
 
 unsigned MmWaveFlexTtiMaxWeightMacScheduler::CalcMinTbSizeNumSym (unsigned mcs, unsigned bufSize, unsigned &tbSize)
 {
-  // bisection line search to find minimum number of slots needed to encode entire buffer
+  // Bisection line search is used to find the minimum number of slots (OFDM symbols)
+  // needed to encode entire buffer.
   MmWaveMacPduHeader dummyMacHeader;
   //unsigned macHdrSize = 10; //dummyMacHeader.GetSerializedSize ();
   int numSymLow = 0;
-  int numSymHigh = m_phyMacConfig->GetSymbolsPerSubframe ();
+  int numSymHigh = m_phyMacConfig->GetSymbolsPerSubframe();
 
   int diff = 0;
-  tbSize = (m_amc->GetTbSizeFromMcsSymbols (mcs, numSymHigh) / 8);       // start with max value
+  tbSize = (m_amc->GetTbSizeFromMcsSymbols (mcs, numSymHigh) / 8); // start with max value, in number of bytes
   while ((unsigned)tbSize > bufSize)
-    {
-      diff = abs (numSymHigh - numSymLow) / 2;
+  {
+      diff = abs(numSymHigh-numSymLow)/2;
       if (diff == 0)
-        {
+      {
           tbSize = (m_amc->GetTbSizeFromMcsSymbols (mcs, numSymHigh) / 8);
           return numSymHigh;
-        }
+      }
       tbSize = (m_amc->GetTbSizeFromMcsSymbols (mcs, numSymHigh - diff) / 8);
-      if ((unsigned)tbSize > bufSize)
-        {
+      if ((unsigned)tbSize >= bufSize)
+      {
           numSymHigh -= diff;
-        }
+      }
+      if ((unsigned) tbSize == bufSize)
+      {
+          return numSymHigh;
+      }
       while ((unsigned)tbSize < bufSize)
-        {
-          diff = abs (numSymHigh - numSymLow) / 2;
+      {
+          diff = abs(numSymHigh-numSymLow)/2;
           if (diff == 0)
-            {
+          {
               tbSize = (m_amc->GetTbSizeFromMcsSymbols (mcs, numSymHigh) / 8);
               return numSymHigh;
-            }
-          //tmp2 = numSym;
+          }
           tbSize = (m_amc->GetTbSizeFromMcsSymbols (mcs, numSymLow + diff) / 8);
-          if ((unsigned)tbSize < bufSize)
-            {
+          if ((unsigned)tbSize <= bufSize)
+          {
               numSymLow += diff;
-            }
-        }
-    }
-
+          }
+          if ((unsigned) tbSize == bufSize)
+          {
+              return numSymLow;
+          }
+      }
+  }
   tbSize = (m_amc->GetTbSizeFromMcsSymbols (mcs, numSymHigh) / 8);
   return (unsigned)numSymHigh;
 }

--- a/src/mmwave/model/mmwave-flex-tti-pf-mac-scheduler.cc
+++ b/src/mmwave/model/mmwave-flex-tti-pf-mac-scheduler.cc
@@ -706,44 +706,51 @@ MmWaveFlexTtiPfMacScheduler::UpdateUlHarqProcessId (uint16_t rnti)
 
 unsigned MmWaveFlexTtiPfMacScheduler::CalcMinTbSizeNumSym (unsigned mcs, unsigned bufSize, unsigned &tbSize)
 {
-  // bisection line search to find minimum number of slots needed to encode entire buffer
+  // Bisection line search is used to find the minimum number of slots (OFDM symbols)
+  // needed to encode entire buffer.
   MmWaveMacPduHeader dummyMacHeader;
   //unsigned macHdrSize = 10; //dummyMacHeader.GetSerializedSize ();
   int numSymLow = 0;
-  int numSymHigh = m_phyMacConfig->GetSymbolsPerSubframe ();
+  int numSymHigh = m_phyMacConfig->GetSymbolsPerSubframe();
 
   int diff = 0;
-  tbSize = (m_amc->GetTbSizeFromMcsSymbols (mcs, numSymHigh) / 8);       // start with max value
+  tbSize = (m_amc->GetTbSizeFromMcsSymbols (mcs, numSymHigh) / 8); // start with max value, in number of bytes
   while ((unsigned)tbSize > bufSize)
-    {
-      diff = abs (numSymHigh - numSymLow) / 2;
+  {
+      diff = abs(numSymHigh-numSymLow)/2;
       if (diff == 0)
-        {
+      {
           tbSize = (m_amc->GetTbSizeFromMcsSymbols (mcs, numSymHigh) / 8);
           return numSymHigh;
-        }
+      }
       tbSize = (m_amc->GetTbSizeFromMcsSymbols (mcs, numSymHigh - diff) / 8);
-      if ((unsigned)tbSize > bufSize)
-        {
+      if ((unsigned)tbSize >= bufSize)
+      {
           numSymHigh -= diff;
-        }
+      }
+      if ((unsigned) tbSize == bufSize)
+      {
+          return numSymHigh;
+      }
       while ((unsigned)tbSize < bufSize)
-        {
-          diff = abs (numSymHigh - numSymLow) / 2;
+      {
+          diff = abs(numSymHigh-numSymLow)/2;
           if (diff == 0)
-            {
+          {
               tbSize = (m_amc->GetTbSizeFromMcsSymbols (mcs, numSymHigh) / 8);
               return numSymHigh;
-            }
-          //tmp2 = numSym;
+          }
           tbSize = (m_amc->GetTbSizeFromMcsSymbols (mcs, numSymLow + diff) / 8);
-          if ((unsigned)tbSize < bufSize)
-            {
+          if ((unsigned)tbSize <= bufSize)
+          {
               numSymLow += diff;
-            }
-        }
-    }
-
+          }
+          if ((unsigned) tbSize == bufSize)
+          {
+              return numSymLow;
+          }
+      }
+  }
   tbSize = (m_amc->GetTbSizeFromMcsSymbols (mcs, numSymHigh) / 8);
   return (unsigned)numSymHigh;
 }


### PR DESCRIPTION
**This patch was provided by Qiang Hu.**
 
In some cases, the method MmWaveFlexTtiMacScheduler::CalcMinTbSizeNumSym was not correctly computing the number of symbols and the associated TB size.
The first figure shows the old behavior, the second figure shows the results obtained after applying this patch (xAxis=buffer size, yAxis=number of symbols). 
![wrong_sym](https://user-images.githubusercontent.com/33095070/69804767-8e3d9080-11df-11ea-87ed-32fc5d6e63b5.png)
![patched_sym](https://user-images.githubusercontent.com/33095070/69804970-f8eecc00-11df-11ea-83c9-2570081a5dc7.png)