### PR TITLE
Fix copy constructor of MmwaveSpectrumSignalParametersDataFrame

### DIFF
--- a/src/mmwave/model/mmwave-spectrum-signal-parameters.cc
+++ b/src/mmwave/model/mmwave-spectrum-signal-parameters.cc
@@ -83,6 +83,7 @@ MmwaveSpectrumSignalParametersDataFrame::MmwaveSpectrumSignalParametersDataFrame
       packetBurst = p.packetBurst->Copy ();
     }
   ctrlMsgList = p.ctrlMsgList;
+  slotInd = p.slotInd;
 }
 
 Ptr<SpectrumSignalParameters>


### PR DESCRIPTION
Add a missing private variable to the copy constructor of MmwaveSpectrumSignalParametersDataFrame