### PR TITLE
Fix memleak in mmwave-beamforming

### DIFF
--- a/src/mmwave/model/mmwave-beamforming.cc
+++ b/src/mmwave/model/mmwave-beamforming.cc
@@ -617,6 +617,9 @@ MmWaveBeamforming::DoCalcRxPowerSpectralDensity (Ptr<const SpectrumValue> txPsd,
         {
           bfParams->m_ueW = ueW;
           bfParams->m_enbW = enbW;
+          if (bfParams->m_beam) {
+            delete bfParams->m_beam;
+          }
           bfParams->m_beam = GetLongTermFading (bfParams);
         }
       else if (ueW.empty ())


### PR DESCRIPTION
Free memory used by previous bfParams->m_beam
before allocation more space for new values in
GetLongTermFading called in DoCalcRxPowerSpectralDensity(...)